### PR TITLE
feat(security): disable form login and enable HTTP Basic Authenticati…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,8 @@ RUN ./gradlew clean build -x test --no-daemon
 # Expose the port on which the Spring Boot app will run
 EXPOSE 8080
 
+# Use environment variable to define the profile (default to prod)
+ENV SPRING_PROFILES_ACTIVE=prod
+
 # Define the entry point for the container to run the JAR file
 CMD ["java", "-jar", "build/libs/examprep_backend-0.0.1-SNAPSHOT.jar"]

--- a/src/main/java/org/backend/examprep_backend/ExamprepBackendApplication.java
+++ b/src/main/java/org/backend/examprep_backend/ExamprepBackendApplication.java
@@ -35,7 +35,7 @@ public class ExamprepBackendApplication {
         }
 
         // You can specify additional conditions based on your requirements
-        boolean isValid = containsProfile(activeProfiles, "local") || containsProfile(activeProfiles, "prod");
+        boolean isValid = containsProfile(activeProfiles, "prod") || containsProfile(activeProfiles, "local");
 
         if (!isValid) {
             throw new IllegalStateException("The application must be run with either 'local' or 'prod' profile.");

--- a/src/main/java/org/backend/examprep_backend/config/SecurityConfig.java
+++ b/src/main/java/org/backend/examprep_backend/config/SecurityConfig.java
@@ -3,7 +3,7 @@ package org.backend.examprep_backend.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -16,12 +16,14 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // Disable CSRF for testing purposes (re-enable in production)
+                .csrf(AbstractHttpConfigurer::disable) // Disable CSRF for testing purposes (re-enable in production)
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/users/register", "/api/users/**").permitAll() // Allow access to register and user endpoints
+                        .requestMatchers("/api/users/register", "/api/users/login").permitAll() // Allow access to register and user endpoints
                         .anyRequest().authenticated() // All other endpoints require authentication
                 )
-                .httpBasic(withDefaults()); // Enable basic authentication for testing
+                .httpBasic(withDefaults()) // Enable basic authentication for testing
+                .formLogin(AbstractHttpConfigurer::disable
+                );
 
         return http.build();
     }


### PR DESCRIPTION
…on for specific endpoints

- Updated SecurityConfig to disable form login globally, ensuring no login forms are presented during authentication.
- Enabled public access for `/api/users/register` and `/api/users/login` endpoints without requiring authentication.
- Secured all other endpoints with HTTP Basic Authentication, requiring valid credentials for access.

This update ensures smooth API access for registration and login endpoints while maintaining strict security for protected resources.