### PR TITLE
feat: Integrated Swagger UI for API documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core' // For mocking services
     testImplementation 'org.mockito:mockito-junit-jupiter' // For JUnit 5 integration with Mockito
 
+    //adding swagger ui
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2' // In-memory database for integration tests

--- a/src/main/java/org/backend/examprep_backend/config/SecurityConfig.java
+++ b/src/main/java/org/backend/examprep_backend/config/SecurityConfig.java
@@ -18,7 +18,11 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable) // Disable CSRF for testing purposes (re-enable in production)
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/users/register", "/api/users/login").permitAll() // Allow access to register and user endpoints
+                        // Allow access to register, login, and Swagger UI
+                        .requestMatchers("/api/users/register", "/api/users/login",
+                                "/swagger-ui.html", "/v3/api-docs/**",
+                                "/swagger-ui/**", "/swagger-resources/**",
+                                "/webjars/**").permitAll()
                         .anyRequest().authenticated() // All other endpoints require authentication
                 )
                 .httpBasic(withDefaults()) // Enable basic authentication for testing


### PR DESCRIPTION
- Added springdoc-openapi dependency to enable Swagger UI integration.
- Configured Swagger to automatically expose API documentation at `/swagger-ui.html`.
- Executed `./gradlew clean build` to ensure successful build with the new dependencies.

This commit enhances API visibility and simplifies endpoint testing with an interactive Swagger UI.